### PR TITLE
Enabled to inject preferred directory for globbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enabled to inject preferred directory for globbing
 - DRYed checkers
 - Rebranded from clubrule to inhouse
 - Renamed Dir prefixes for simplicity

--- a/checks.go
+++ b/checks.go
@@ -66,8 +66,8 @@ func (c *Check) Sort() {
 // SourcesContains returns true when source files in the caller directory contains the specified Go function.
 // The starting directory is where you call this function.
 // This function will not check for `*_test.go` files.
-func SourcesContains(function string, recursive bool) (*Check, error) {
-	files, err := Sources(recursive)
+func SourcesContains(dir, function string, recursive bool) (*Check, error) {
+	files, err := Sources(dir, recursive)
 
 	if err != nil {
 		return nil, err
@@ -79,8 +79,8 @@ func SourcesContains(function string, recursive bool) (*Check, error) {
 // TestsContains returns true when test files in the caller directory contains the specified Go function.
 // The starting directory is where you call this function.
 // This function will check for `*_test.go` files only.
-func TestsContains(function string, recursive bool) (*Check, error) {
-	files, err := Tests(recursive)
+func TestsContains(dir, function string, recursive bool) (*Check, error) {
+	files, err := Tests(dir, recursive)
 
 	if err != nil {
 		return nil, err

--- a/checks_test.go
+++ b/checks_test.go
@@ -91,6 +91,7 @@ func TestSourcesContains(t *testing.T) {
 	{
 		// Success cases
 		type pattern struct {
+			dir       string
 			name      string
 			recursive bool
 			expected  bool
@@ -98,16 +99,37 @@ func TestSourcesContains(t *testing.T) {
 
 		pats := []pattern{
 			{
+				dir:       "",
 				name:      "SourcesContains",
 				recursive: false,
 				expected:  true,
 			},
 			{
+				dir:       "./",
+				name:      "SourcesContains",
+				recursive: false,
+				expected:  true,
+			},
+			{
+				dir:       "./",
+				name:      "SourcesContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "./testdata",
+				name:      "SourcesContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "",
 				name:      "ExportOnly1",
 				recursive: false,
 				expected:  false,
 			},
 			{
+				dir:       "",
 				name:      "ExportOnly1",
 				recursive: true,
 				expected:  true,
@@ -115,10 +137,34 @@ func TestSourcesContains(t *testing.T) {
 		}
 
 		for _, p := range pats {
-			got, err := SourcesContains(p.name, p.recursive)
+			got, err := SourcesContains(p.dir, p.name, p.recursive)
 
 			require.NoError(t, err)
 			assert.Equalf(t, p.expected, got.Contained, spew.Sdump(p))
+		}
+	}
+
+	{
+		// Fail cases
+		type pattern struct {
+			dir       string
+			recursive bool
+			expected  bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "non-existent",
+				recursive: false,
+				expected:  true,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := SourcesContains(p.dir, "foo", p.recursive)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
 		}
 	}
 }
@@ -127,6 +173,7 @@ func TestTestsContains(t *testing.T) {
 	{
 		// Success cases
 		type pattern struct {
+			dir       string
 			name      string
 			recursive bool
 			expected  bool
@@ -134,11 +181,13 @@ func TestTestsContains(t *testing.T) {
 
 		pats := []pattern{
 			{
+				dir:       "",
 				name:      "SourcesContains",
 				recursive: false,
 				expected:  false,
 			},
 			{
+				dir:       "",
 				name:      "TestTestsContains",
 				recursive: false,
 				expected:  true,
@@ -146,7 +195,7 @@ func TestTestsContains(t *testing.T) {
 		}
 
 		for _, p := range pats {
-			got, err := TestsContains(p.name, p.recursive)
+			got, err := TestsContains(p.dir, p.name, p.recursive)
 
 			require.NoError(t, err)
 			assert.Equalf(t, p.expected, got.Contained, spew.Sdump(p))

--- a/glob_test.go
+++ b/glob_test.go
@@ -12,22 +12,37 @@ import (
 
 func TestSources(t *testing.T) {
 	{
-		// Success cases, recursive
+		// Success cases
 		type pattern struct {
+			dir       string
 			recursive bool
 		}
 
 		pats := []pattern{
 			{
+				dir:       "",
 				recursive: true,
 			},
 			{
+				dir:       "",
+				recursive: false,
+			},
+			{
+				dir:       "./",
+				recursive: false,
+			},
+			{
+				dir:       "./testdata",
+				recursive: false,
+			},
+			{
+				dir:       "./.github",
 				recursive: false,
 			},
 		}
 
 		for _, p := range pats {
-			got, err := Sources(p.recursive)
+			got, err := Sources(p.dir, p.recursive)
 
 			require.NoError(t, err)
 			assert.NotNil(t, got)
@@ -42,7 +57,28 @@ func TestSources(t *testing.T) {
 
 	{
 		// Fail cases
-		// TODO
+		type pattern struct {
+			dir       string
+			recursive bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "non-existent",
+				recursive: false,
+			},
+			{
+				dir:       "non-existent",
+				recursive: true,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := Sources(p.dir, p.recursive)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
+		}
 	}
 }
 
@@ -50,20 +86,27 @@ func TestTests(t *testing.T) {
 	{
 		// Success cases, recursive
 		type pattern struct {
+			dir       string
 			recursive bool
 		}
 
 		pats := []pattern{
 			{
+				dir:       "",
 				recursive: true,
 			},
 			{
+				dir:       "",
 				recursive: false,
+			},
+			{
+				dir:       "./",
+				recursive: true,
 			},
 		}
 
 		for _, p := range pats {
-			got, err := Tests(p.recursive)
+			got, err := Tests(p.dir, p.recursive)
 
 			require.NoError(t, err)
 			assert.NotNil(t, got)
@@ -78,7 +121,67 @@ func TestTests(t *testing.T) {
 
 	{
 		// Fail cases
-		// TODO
+		type pattern struct {
+			dir       string
+			recursive bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "non-existent",
+				recursive: false,
+			},
+			{
+				dir:       "non-existent",
+				recursive: true,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := Tests(p.dir, p.recursive)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
+		}
+	}
+}
+func TestGlobDir(t *testing.T) {
+	{
+		// Success cases
+		type pattern struct {
+			dir string
+		}
+
+		pats := []pattern{
+			{dir: ""},
+			{dir: "testdata"},
+			{dir: "./testdata"},
+		}
+
+		for _, p := range pats {
+			got, err := globDir(p.dir)
+
+			require.NoErrorf(t, err, spew.Sdump(p))
+			assert.NotSamef(t, p.dir, got, spew.Sdump(p))
+		}
+	}
+
+	{
+		// Fail cases
+		type pattern struct {
+			dir string
+		}
+
+		pats := []pattern{
+			{dir: "non-existent"},
+		}
+
+		for _, p := range pats {
+			got, err := globDir(p.dir)
+
+			require.Errorf(t, err, spew.Sdump(p))
+			assert.Emptyf(t, got, spew.Sdump(p))
+		}
 	}
 }
 
@@ -109,8 +212,8 @@ func TestGlob(t *testing.T) {
 		for _, p := range pats {
 			got, err := glob(p)
 
-			require.NoError(t, err)
-			assert.True(t, len(got) > 0)
+			require.NoErrorf(t, err, spew.Sdump(p))
+			assert.Truef(t, len(got) > 0, spew.Sdump(p))
 
 			for _, g := range got {
 				name := filepath.Base(g)
@@ -133,8 +236,8 @@ func TestGlob(t *testing.T) {
 		for _, p := range pats {
 			got, err := glob(p)
 
-			require.Error(t, err)
-			assert.Nil(t, got)
+			require.Errorf(t, err, spew.Sdump(p))
+			assert.Nilf(t, got, spew.Sdump(p))
 		}
 	}
 }

--- a/pwd.go
+++ b/pwd.go
@@ -10,7 +10,7 @@ import (
 // PWD returns an absolute path of caller origin.
 func PWD() (string, error) {
 
-	_, filename, _, ok := runtime.Caller(1)
+	_, filename, _, ok := runtime.Caller(3)
 
 	if !ok {
 		return "", errors.New("failed to retrieve runtime caller")


### PR DESCRIPTION
Preparation step for CLI integration, to enable to specify any directory to glob the source codes.
The existing code was implicitly resolving the caller's directory, therefore this PR enables to pass `dir` as parameter and fallback to pwd.