### PR TITLE
Extended Code struct with decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extended Code struct with decorators (colon, csv, tsv, json)
 - Added Mozilla Public License 2.0
 
 ### Changed
 
+- Prefixed log with DEBUG marker
 - Output coverage report after test
 
 ## [0.1.0] - 2021-04-18

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,7 +1,8 @@
 package main
 
 const (
-	dirFlag  = "dir"
-	exitFlag = "exit"
-	listFlag = "list"
+	dirFlag    = "dir"
+	exitFlag   = "exit"
+	formatFlag = "format"
+	listFlag   = "list"
 )

--- a/cli/run.go
+++ b/cli/run.go
@@ -25,6 +25,18 @@ func run(args []string) error {
 						Usage:   fmt.Sprintf("target `%s`", strings.ToUpper(dirFlag)),
 						Aliases: []string{"d"},
 					},
+					&cli.StringFlag{
+						Name: formatFlag,
+						Usage: fmt.Sprintf(
+							"select output `FORMAT` (%s, %s, %s, %s)",
+							inhouse.ColonFormat.String(),
+							inhouse.CSVFormat.String(),
+							inhouse.TSVFormat.String(),
+							inhouse.JSONFormat.String(),
+						),
+						DefaultText: inhouse.ColonFormat.String(),
+						Aliases:     []string{"f"},
+					},
 					&cli.BoolFlag{
 						Name:    exitFlag,
 						Usage:   "terminate with exit code 2 on match",
@@ -38,6 +50,7 @@ func run(args []string) error {
 				},
 				Action: func(c *cli.Context) error {
 					dir := c.String(dirFlag)
+					format := c.String(formatFlag)
 					name := c.Args().Get(0)
 
 					got, err := inhouse.SourcesContains(dir, name, true)
@@ -48,14 +61,14 @@ func run(args []string) error {
 
 					if c.Bool(listFlag) {
 						for _, c := range got.Combine() {
-							fmt.Printf("%s %s\n", c.Filepath, c.Function)
+							fmt.Println(c.Format(inhouse.CodeFormat(format)))
 						}
 
 						return nil
 					}
 
 					for _, c := range got.Matches {
-						fmt.Printf("%s:%d\n", c.Filepath, c.Line)
+						fmt.Println(c.Format(inhouse.CodeFormat(format)))
 					}
 
 					if got.Contained && c.Bool(exitFlag) {

--- a/code.go
+++ b/code.go
@@ -1,14 +1,80 @@
 package inhouse
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"sort"
+)
+
+// CodeFormat represents print styles.
+type CodeFormat string
+
+// String output.
+func (c CodeFormat) String() string {
+	return string(c)
+}
+
+// List of code formats.
+const (
+	CSVFormat   CodeFormat = "csv"
+	ColonFormat CodeFormat = "colon"
+	JSONFormat  CodeFormat = "json"
+	TSVFormat   CodeFormat = "tsv"
 )
 
 // Code represents a Go code with some information for post processing.
 type Code struct {
-	Filepath string
-	Function string
-	Line     int
+	Filepath string `json:"filePath"`
+	Function string `json:"function"`
+	Line     int    `json:"line"`
+}
+
+// Format code to applicable styles.
+// Suitable to be used together with CLI flags.
+func (c Code) Format(style CodeFormat) string {
+	switch style {
+
+	case CSVFormat:
+		return c.ToCSV()
+
+	case JSONFormat:
+		return c.ToJSON()
+
+	case TSVFormat:
+		return c.ToTSV()
+	}
+
+	return c.ToColon()
+}
+
+// ToColon is a decorator to print fields in colon-separated format.
+func (c Code) ToColon() string {
+	return fmt.Sprintf("%s:%s:%d", c.Filepath, c.Function, c.Line)
+}
+
+// ToCSV is a decorator to print fields in comma-separated format.
+func (c Code) ToCSV() string {
+	return fmt.Sprintf("%s,%s,%d", c.Filepath, c.Function, c.Line)
+}
+
+// ToTSV is a decorator to print fields in tab-separated format.
+func (c Code) ToTSV() string {
+	return fmt.Sprintf("%s\t%s\t%d", c.Filepath, c.Function, c.Line)
+}
+
+// ToJSON is a decorator to print fields in JSON format.
+// Note this method will exit immediately on failure.
+func (c Code) ToJSON() string {
+
+	b, err := json.Marshal(c)
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	return string(b)
 }
 
 // Sort slice of code by filename.

--- a/code_test.go
+++ b/code_test.go
@@ -6,6 +6,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCodeFormatString(t *testing.T) {
+	assert.Equal(t, string(CSVFormat), CSVFormat.String())
+}
+
+func TestCodeDecorators(t *testing.T) {
+	c := Code{
+		Filepath: "/a",
+		Function: "b",
+		Line:     100,
+	}
+
+	var (
+		colon = "/a:b:100"
+		csv   = "/a,b,100"
+		tsv   = "/a\tb\t100"
+		json  = `{"filePath":"/a","function":"b","line":100}`
+	)
+
+	// Check raw outputs.
+	assert.Equal(t, colon, c.ToColon())
+	assert.Equal(t, csv, c.ToCSV())
+	assert.Equal(t, tsv, c.ToTSV())
+	assert.Equal(t, json, c.ToJSON())
+
+	// Check wrapper results are exactly the same.
+	assert.Equal(t, c.ToColon(), c.Format(ColonFormat))
+	assert.Equal(t, c.ToCSV(), c.Format(CSVFormat))
+	assert.Equal(t, c.ToTSV(), c.Format(TSVFormat))
+	assert.Equal(t, c.ToJSON(), c.Format(JSONFormat))
+}
+
 func TestSortCode(t *testing.T) {
 
 	got := sortCode([]*Code{

--- a/logger.go
+++ b/logger.go
@@ -15,6 +15,8 @@ func Log(msg ...string) {
 		return
 	}
 
+	fmt.Print(debug, ": ")
+
 	for i, m := range msg {
 		fmt.Print(m)
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,6 +2,7 @@ package inhouse
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -50,15 +51,18 @@ func TestLog(t *testing.T) {
 		orig := os.Getenv(debug)
 		os.Setenv(debug, "1")
 
-		expected := "hello"
-		Log(expected)
+		sample := "hello"
+		Log(sample)
 		w.Close()
 
 		var buf bytes.Buffer
 		_, err = buf.ReadFrom(r)
 		require.NoError(t, err)
 
-		assert.Equal(t, expected, strings.TrimRight(buf.String(), "\n"))
+		exp := fmt.Sprintf("%s: %s", debug, sample)
+		got := strings.TrimRight(buf.String(), "\n")
+
+		assert.Equal(t, exp, got)
 
 		// Teardown
 		os.Setenv(debug, orig)


### PR DESCRIPTION
Added some features for better CLI experience.

1. Decorators --> colon/csv/tsv-separated and JSON line
2. Debug message --> Prefixed with `DEBUG: ` for clarity