### PR TITLE
Fixed wrong path calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefixed log with DEBUG marker
 - Output coverage report after test
 
+### Fixed
+
+- Incorrect path was returned when tilda is specified
+
 ## [0.1.0] - 2021-04-18
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Captured runtime error
+
 ## [0.1.0] - 2021-04-18
 
 ### Added

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 )
 
 func main() {
-	_ = run(os.Args)
+	if err := run(os.Args); err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -18,7 +18,7 @@ func run(args []string) error {
 			{
 				Name:    "function",
 				Usage:   "search for function name",
-				Aliases: []string{"f"},
+				Aliases: []string{"f", "functions", "funcs"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:    dirFlag,

--- a/glob.go
+++ b/glob.go
@@ -73,11 +73,25 @@ func globDir(given string) (string, error) {
 		target = pwd
 
 	default:
+		home, err := os.UserHomeDir()
+
+		if err != nil {
+			return "", err
+		}
+
+		for _, c := range []string{"/", "/home", home} {
+			if c == given {
+				return "", fmt.Errorf("directory '%s' is too broad which could bloat your machine's CPU usage", given)
+			}
+		}
+
 		cwd, err := os.Getwd()
 
 		if err != nil {
 			return "", err
 		}
+
+		Log("os.Getwd", cwd)
 
 		stat, err := os.Stat(given)
 
@@ -88,7 +102,12 @@ func globDir(given string) (string, error) {
 		dir := given
 
 		if !stat.IsDir() {
-			dir = filepath.Dir(given)
+			dir = filepath.Dir(dir)
+		}
+
+		if filepath.IsAbs(dir) {
+			target = dir
+			break
 		}
 
 		got, err := filepath.Abs(filepath.Join(cwd, dir))

--- a/glob_test.go
+++ b/glob_test.go
@@ -182,6 +182,9 @@ func TestGlobDir(t *testing.T) {
 
 		pats := []pattern{
 			{dir: "non-existent"},
+			{dir: "~"},
+			{dir: "/"},
+			{dir: "/home"},
 		}
 
 		for _, p := range pats {


### PR DESCRIPTION
Incorrect path was returned when tilda (`~`) is specified.
Also added a safe switch to prevent potential CPU bloat.