### PR TITLE
Defined CLIENV for cli/source/test switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Defined CLIENV for cli/source/test switching
+
 ### Changed
 
 - Moved cli to cli/inhouse for go get install

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,5 @@
+package inhouse
+
+// CLIENV is a special environment variable only present during CLI run.
+// Used internally to determine the caller is CLI/source/tests.
+const CLIENV = "INHOUSECLI"

--- a/cli/inhouse/CHANGELOG.md
+++ b/cli/inhouse/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Injected CLIENV before run
+
 ### Changed
 
 - Renamed module reference to github.com/tomodian/inhouse

--- a/cli/inhouse/main.go
+++ b/cli/inhouse/main.go
@@ -3,9 +3,13 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/tomodian/inhouse"
 )
 
 func main() {
+	os.Setenv(inhouse.CLIENV, "yes")
+
 	if err := run(os.Args); err != nil {
 		fmt.Println(err)
 		os.Exit(2)

--- a/pwd.go
+++ b/pwd.go
@@ -3,6 +3,7 @@ package inhouse
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -10,13 +11,31 @@ import (
 // PWD returns an absolute path of caller origin.
 func PWD() (string, error) {
 
-	_, filename, _, ok := runtime.Caller(2)
+	cwd := ""
 
-	if !ok {
-		return "", errors.New("failed to retrieve runtime caller")
+	if os.Getenv(CLIENV) == "" {
+		// Comes into this context when called by source/test code.
+		// https://stackoverflow.com/a/36666114/515244
+		_, filename, _, ok := runtime.Caller(2)
+
+		if !ok {
+			return "", errors.New("failed to retrieve runtime caller")
+		}
+
+		cwd = filename
+
+	} else {
+		// Comes into this context when called by CLI.
+		got, err := os.Getwd()
+
+		if err != nil {
+			return "", err
+		}
+
+		cwd = got
 	}
 
-	dir, err := filepath.Abs(filepath.Dir(filename))
+	dir, err := filepath.Abs(filepath.Dir(cwd))
 
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve filepath, %s", err)

--- a/pwd.go
+++ b/pwd.go
@@ -15,7 +15,6 @@ func PWD() (string, error) {
 
 	if os.Getenv(CLIENV) == "" {
 		// Comes into this context when called by source/test code.
-		// https://stackoverflow.com/a/36666114/515244
 		_, filename, _, ok := runtime.Caller(2)
 
 		if !ok {

--- a/pwd_test.go
+++ b/pwd_test.go
@@ -1,6 +1,7 @@
 package inhouse
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -9,10 +10,23 @@ import (
 )
 
 func TestPWD(t *testing.T) {
+	{
+		// Success case, source mode
+		got, err := PWD()
 
-	got, err := PWD()
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+		assert.False(t, strings.HasSuffix(got, ".go"))
+	}
 
-	require.NoError(t, err)
-	assert.NotEmpty(t, got)
-	assert.False(t, strings.HasSuffix(got, ".go"))
+	{
+		// Success case, CLI mode
+		os.Setenv(CLIENV, "yes")
+
+		got, err := PWD()
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+		assert.False(t, strings.HasSuffix(got, ".go"))
+	}
 }


### PR DESCRIPTION
This PR adds a context switch with the following behaviors:

- CLI mode: PWD is set to the current caller directory
- Source / test mode: uses runtime.Caller(2)