### PR TITLE
Contains and ContainsPWD checks to target both source and test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode
+*.log
 *.tmp
 build
 coverage.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Contains and ContainsPWD checks to target both source and test files
+
+### Changed
+
+- Renamed Contains to matchFunction, and use Contain as Sources/Tests wrapper
+
+### Fixed
+
+- PWD was returning the upper directory when given parameter is a directory
+
 ## [0.3.0] - 2021-04-20
 
 ### Added

--- a/checks.go
+++ b/checks.go
@@ -20,6 +20,9 @@ type Check struct {
 	Contained bool    `json:"contained"`
 	Matches   []*Code `json:"matches"`
 	Misses    []*Code `json:"misses"`
+
+	// Just for testing.
+	Tester interface{} `json:"tester,omitempty"`
 }
 
 // NewCheck with initialized slices.

--- a/checks.go
+++ b/checks.go
@@ -1,5 +1,9 @@
 package inhouse
 
+import (
+	"encoding/json"
+)
+
 // ContainsOutput represents a matching result of code.
 type ContainsOutput struct {
 	Contained bool
@@ -13,9 +17,9 @@ func (c ContainsOutput) HasCode() bool {
 
 // Check represents a checker result.
 type Check struct {
-	Contained bool
-	Matches   []*Code
-	Misses    []*Code
+	Contained bool    `json:"contained"`
+	Matches   []*Code `json:"matches"`
+	Misses    []*Code `json:"misses"`
 }
 
 // NewCheck with initialized slices.
@@ -45,6 +49,18 @@ func (c *Check) Combine() []*Code {
 	out = append(out, c.Misses...)
 
 	return sortCode(out)
+}
+
+// ToJSON for CLI output.
+func (c Check) ToJSON() (string, error) {
+
+	b, err := json.Marshal(c)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }
 
 // Contains returns true when source files in the caller directory contains the specified Go function.

--- a/checks_test.go
+++ b/checks_test.go
@@ -35,7 +35,7 @@ func TestCheckCombine(t *testing.T) {
 	assert.Equal(t, "/a", got[0].Filepath)
 }
 
-func TestContains(t *testing.T) {
+func TestMatchFunction(t *testing.T) {
 	{
 		// Success cases
 		type pattern struct {
@@ -63,7 +63,7 @@ func TestContains(t *testing.T) {
 		}
 
 		for _, p := range pats {
-			got, err := Contains(testfile(p.path), p.name)
+			got, err := matchFunction(testfile(p.path), p.name)
 
 			require.NoError(t, err)
 			assert.Truef(t, got.HasCode(), spew.Sdump(p))
@@ -86,7 +86,7 @@ func TestContains(t *testing.T) {
 		}
 
 		for _, p := range pats {
-			got, err := Contains(testfile(p.path), p.name)
+			got, err := matchFunction(testfile(p.path), p.name)
 
 			require.NoError(t, err)
 			assert.Falsef(t, got.Contained, spew.Sdump(p))
@@ -97,9 +97,184 @@ func TestContains(t *testing.T) {
 	{
 		// Fail cases
 		for _, p := range nonGoFiles {
-			_, err := Contains(testfile(p), "whatever")
+			_, err := matchFunction(testfile(p), "whatever")
 
 			require.Error(t, err)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	{
+		// Success cases
+		type pattern struct {
+			dir       string
+			name      string
+			recursive bool
+			expected  bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "",
+				name:      "SourcesContains",
+				recursive: false,
+				expected:  true,
+			},
+			{
+				dir:       "./",
+				name:      "SourcesContains",
+				recursive: false,
+				expected:  true,
+			},
+			{
+				dir:       "./",
+				name:      "SourcesContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "",
+				name:      "ExportOnly1",
+				recursive: false,
+				expected:  false,
+			},
+			{
+				dir:       "",
+				name:      "ExportOnly1",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "./testdata",
+				name:      "ExportOnly1",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "",
+				name:      "TestTestsContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				dir:       "examples",
+				name:      "TestInitExists",
+				recursive: true,
+				expected:  true,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := Contains(p.dir, p.name, p.recursive)
+
+			require.NoError(t, err)
+			assert.Equalf(t, p.expected, got.Contained, spew.Sdump(p), spew.Sdump(got))
+		}
+	}
+
+	{
+		// Fail cases
+		type pattern struct {
+			dir       string
+			recursive bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "non-existent",
+				recursive: false,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := Contains(p.dir, "foo", p.recursive)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
+		}
+	}
+}
+
+func TestContainsPWD(t *testing.T) {
+	{
+		// Success cases
+		type pattern struct {
+			name      string
+			recursive bool
+			expected  bool
+		}
+
+		pats := []pattern{
+			{
+				name:      "SourcesContains",
+				recursive: false,
+				expected:  true,
+			},
+			{
+				name:      "SourcesContains",
+				recursive: false,
+				expected:  true,
+			},
+			{
+				name:      "SourcesContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				name:      "ExportOnly1",
+				recursive: false,
+				expected:  false,
+			},
+			{
+				name:      "ExportOnly1",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				name:      "ExportOnly1",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				name:      "TestTestsContains",
+				recursive: true,
+				expected:  true,
+			},
+			{
+				name:      "TestInitExists",
+				recursive: true,
+				expected:  true,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := ContainsPWD(p.name, p.recursive)
+
+			require.NoError(t, err)
+			assert.Equalf(t, p.expected, got.Contained, spew.Sdump(p), spew.Sdump(got))
+		}
+	}
+
+	{
+		// Fail cases
+		type pattern struct {
+			dir       string
+			recursive bool
+		}
+
+		pats := []pattern{
+			{
+				dir:       "non-existent",
+				recursive: false,
+			},
+		}
+
+		for _, p := range pats {
+			got, err := Contains(p.dir, "foo", p.recursive)
+
+			require.Error(t, err)
+			assert.Nil(t, got)
 		}
 	}
 }
@@ -183,6 +358,7 @@ func TestSourcesContains(t *testing.T) {
 		}
 	}
 }
+
 func TestSourcesContainsPWD(t *testing.T) {
 	{
 		// Success cases

--- a/checks_test.go
+++ b/checks_test.go
@@ -35,6 +35,15 @@ func TestCheckCombine(t *testing.T) {
 	assert.Equal(t, "/a", got[0].Filepath)
 }
 
+func TestCheckToJSON(t *testing.T) {
+	d := NewCheck()
+
+	got, err := d.ToJSON()
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}
+
 func TestMatchFunction(t *testing.T) {
 	{
 		// Success cases

--- a/checks_test.go
+++ b/checks_test.go
@@ -36,12 +36,29 @@ func TestCheckCombine(t *testing.T) {
 }
 
 func TestCheckToJSON(t *testing.T) {
-	d := NewCheck()
+	{
+		// Success case
+		d := NewCheck()
 
-	got, err := d.ToJSON()
+		got, err := d.ToJSON()
 
-	require.NoError(t, err)
-	assert.NotEmpty(t, got)
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+	}
+
+	{
+		// Fail case
+		d := NewCheck()
+
+		// Uses this tips to make json.Marshal to fail.
+		// https://stackoverflow.com/a/48901259/515244
+		d.Tester = make(chan int)
+
+		got, err := d.ToJSON()
+
+		require.Error(t, err)
+		assert.Empty(t, got)
+	}
 }
 
 func TestMatchFunction(t *testing.T) {

--- a/cli/inhouse/CHANGELOG.md
+++ b/cli/inhouse/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added flat search and test code inclusion flags
+
 ## [0.3.0] - 2021-04-20
 
 ### Added

--- a/cli/inhouse/flags.go
+++ b/cli/inhouse/flags.go
@@ -3,6 +3,8 @@ package main
 const (
 	dirFlag    = "dir"
 	exitFlag   = "exit"
+	flatFlag   = "flat"
 	formatFlag = "format"
 	listFlag   = "list"
+	testFlag   = "test"
 )

--- a/cli/inhouse/run.go
+++ b/cli/inhouse/run.go
@@ -38,7 +38,7 @@ func run(args []string) error {
 					},
 					&cli.BoolFlag{
 						Name:    exitFlag,
-						Usage:   "terminate with exit code 2 on match",
+						Usage:   "terminate with exit code 1 on match",
 						Aliases: []string{"e"},
 					},
 					&cli.BoolFlag{
@@ -52,35 +52,53 @@ func run(args []string) error {
 						Value: false,
 					},
 					&cli.BoolFlag{
-						Name:  testFlag,
-						Usage: "include test files",
-						Value: false,
+						Name:    testFlag,
+						Usage:   "include test files to search target",
+						Value:   false,
+						Aliases: []string{"t"},
 					},
 				},
 				Action: func(c *cli.Context) error {
 					dir := c.String(dirFlag)
 					format := c.String(formatFlag)
 					name := c.Args().Get(0)
+					flat := !c.Bool(flatFlag)
 
-					got, err := inhouse.SourcesContains(dir, name, !c.Bool(flatFlag))
+					var check *inhouse.Check
 
-					if err != nil {
-						return err
+					switch {
+					case c.Bool(testFlag):
+						got, err := inhouse.Contains(dir, name, flat)
+
+						if err != nil {
+							return err
+						}
+
+						check = got
+
+					default:
+						got, err := inhouse.SourcesContains(dir, name, flat)
+
+						if err != nil {
+							return err
+						}
+
+						check = got
 					}
 
 					if c.Bool(listFlag) {
-						for _, c := range got.Combine() {
+						for _, c := range check.Combine() {
 							fmt.Println(c.Format(inhouse.CodeFormat(format)))
 						}
 
 						return nil
 					}
 
-					for _, c := range got.Matches {
+					for _, c := range check.Matches {
 						fmt.Println(c.Format(inhouse.CodeFormat(format)))
 					}
 
-					if got.Contained && c.Bool(exitFlag) {
+					if check.Contained && c.Bool(exitFlag) {
 						os.Exit(1)
 					}
 

--- a/cli/inhouse/run.go
+++ b/cli/inhouse/run.go
@@ -46,13 +46,23 @@ func run(args []string) error {
 						Usage:   "list all functions and quit",
 						Aliases: []string{"l"},
 					},
+					&cli.BoolFlag{
+						Name:  flatFlag,
+						Usage: "search files in flat directory, defaults to recursive",
+						Value: false,
+					},
+					&cli.BoolFlag{
+						Name:  testFlag,
+						Usage: "include test files",
+						Value: false,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					dir := c.String(dirFlag)
 					format := c.String(formatFlag)
 					name := c.Args().Get(0)
 
-					got, err := inhouse.SourcesContains(dir, name, true)
+					got, err := inhouse.SourcesContains(dir, name, !c.Bool(flatFlag))
 
 					if err != nil {
 						return err

--- a/code.go
+++ b/code.go
@@ -28,6 +28,9 @@ type Code struct {
 	Filepath string `json:"filePath"`
 	Function string `json:"function"`
 	Line     int    `json:"line"`
+
+	// Just for testing.
+	Tester interface{} `json:"tester,omitempty"`
 }
 
 // Format code to applicable styles.

--- a/pwd.go
+++ b/pwd.go
@@ -33,32 +33,31 @@ func PWD() (string, error) {
 		current = got
 	}
 
-	info, err := os.Stat(current)
+	return parseDir(current)
+}
+
+func parseDir(given string) (string, error) {
+	info, err := os.Stat(given)
 
 	if err != nil {
 		return "", err
 	}
 
-	out := ""
-
 	if info.IsDir() {
-		dir, err := filepath.Abs(current)
+		dir, err := filepath.Abs(given)
 
 		if err != nil {
 			return "", err
 		}
 
-		out = dir
-
-	} else {
-		dir, err := filepath.Abs(filepath.Dir(current))
-
-		if err != nil {
-			return "", err
-		}
-
-		out = dir
+		return dir, nil
 	}
 
-	return out, nil
+	dir, err := filepath.Abs(filepath.Dir(given))
+
+	if err != nil {
+		return "", err
+	}
+
+	return dir, nil
 }

--- a/pwd.go
+++ b/pwd.go
@@ -10,8 +10,6 @@ import (
 // PWD returns an absolute path of caller origin.
 func PWD() (string, error) {
 
-	current := ""
-
 	if os.Getenv(CLIENV) == "" {
 		// Comes into this context when called by source/test code.
 		_, filename, _, ok := runtime.Caller(2)
@@ -20,20 +18,17 @@ func PWD() (string, error) {
 			return "", errors.New("failed to retrieve runtime caller")
 		}
 
-		current = filename
-
-	} else {
-		// Comes into this context when called by CLI.
-		got, err := os.Getwd()
-
-		if err != nil {
-			return "", err
-		}
-
-		current = got
+		return parseDir(filename)
 	}
 
-	return parseDir(current)
+	// Comes into this context when called by CLI.
+	got, err := os.Getwd()
+
+	if err != nil {
+		return "", err
+	}
+
+	return parseDir(got)
 }
 
 func parseDir(given string) (string, error) {

--- a/pwd.go
+++ b/pwd.go
@@ -2,7 +2,6 @@ package inhouse
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,7 +10,7 @@ import (
 // PWD returns an absolute path of caller origin.
 func PWD() (string, error) {
 
-	cwd := ""
+	current := ""
 
 	if os.Getenv(CLIENV) == "" {
 		// Comes into this context when called by source/test code.
@@ -21,7 +20,7 @@ func PWD() (string, error) {
 			return "", errors.New("failed to retrieve runtime caller")
 		}
 
-		cwd = filename
+		current = filename
 
 	} else {
 		// Comes into this context when called by CLI.
@@ -31,14 +30,35 @@ func PWD() (string, error) {
 			return "", err
 		}
 
-		cwd = got
+		current = got
 	}
 
-	dir, err := filepath.Abs(filepath.Dir(cwd))
+	info, err := os.Stat(current)
 
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve filepath, %s", err)
+		return "", err
 	}
 
-	return dir, nil
+	out := ""
+
+	if info.IsDir() {
+		dir, err := filepath.Abs(current)
+
+		if err != nil {
+			return "", err
+		}
+
+		out = dir
+
+	} else {
+		dir, err := filepath.Abs(filepath.Dir(current))
+
+		if err != nil {
+			return "", err
+		}
+
+		out = dir
+	}
+
+	return out, nil
 }

--- a/pwd_test.go
+++ b/pwd_test.go
@@ -2,7 +2,6 @@ package inhouse
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,11 @@ func TestPWD(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, got)
-		assert.False(t, strings.HasSuffix(got, ".go"))
+
+		info, err := os.Stat(got)
+
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
 	}
 
 	{
@@ -27,7 +30,11 @@ func TestPWD(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, got)
-		assert.False(t, strings.HasSuffix(got, ".go"))
+
+		info, err := os.Stat(got)
+
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
 	}
 }
 

--- a/pwd_test.go
+++ b/pwd_test.go
@@ -30,3 +30,34 @@ func TestPWD(t *testing.T) {
 		assert.False(t, strings.HasSuffix(got, ".go"))
 	}
 }
+
+func TestParseDir(t *testing.T) {
+	{
+		// Success case
+		pats := []string{
+			"./",
+			"./testdata",
+		}
+
+		for _, p := range pats {
+			got, err := parseDir(p)
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, got)
+		}
+	}
+
+	{
+		// Fail cases
+		pats := []string{
+			"./non-existent",
+		}
+
+		for _, p := range pats {
+			got, err := parseDir(p)
+
+			require.Error(t, err)
+			assert.Empty(t, got)
+		}
+	}
+}


### PR DESCRIPTION

### Added

- Contains and ContainsPWD checks to target both source and test files

### Changed

- Renamed Contains to matchFunction, and use Contain as Sources/Tests wrapper

### Fixed

- PWD was returning the upper directory when given parameter is a directory